### PR TITLE
Little glitch with fetch_rate and ridiculously disparate currencies

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -101,7 +101,7 @@ class Money
 
         error = data['error']
         raise UnknownRate unless error == '' || error == '0'
-        BigDecimal(data['rhs'].split(' ')[0])
+        BigDecimal(data['rhs'].gsub(/[^\d\.]/, ''))
       end
 
       ##


### PR DESCRIPTION
The fetch_rate methods improperly parses results from google currency when the returned value is greater than 1000.

For example, USD to KRW (S. Korean Won) has an exchange rate of 1 to 1101.32159.  The JSON response from Google (http://www.google.com/ig/calculator?hl=en&q=1USD=?KRW) looks like so:

{lhs: "1 U.S. dollar",rhs: "1 101.32159 South Korean won",error: "",icc: true}

Using a split(' ')[0] method will result in an incorrect value of 1, instead of 1101.32159.

I've modified the code to call gsub(/[^\d.]/, '') to strip out any non-digit characters, while leaving in the decimal place.  This will convert a returned rhs value of "1 101.32159 South Korean won" to "1101.32159"

Very handy library, much thanks!
