### PR TITLE
Travis build status in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 Google Currency
 ===============
 
+[![Build Status](https://secure.travis-ci.org/RubyMoney/google_currency.png)](http://travis-ci.org/RubyMoney/google_currency)
+
 This gem extends Money::Bank::VariableExchange with Money::Bank::GoogleCurrency
 and gives you access to the current Google Currency exchange rates.
 


### PR DESCRIPTION
I've added the TravisCI build status image in the README.

BTW, right now the build fails on JRuby because of YAJL.
