### PR TITLE
Another Little glitch with fetch_rate and ridiculously disparate currencies

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -82,7 +82,10 @@ class Money
 
         error = data['error']
         raise UnknownRate unless error == '' || error == '0'
-        BigDecimal(data['rhs'].gsub(/[^\d\.]/, ''))
+        rate = BigDecimal(data['rhs'].match(/\d[\d\s]*\.?\d*/)[0])
+        power = data['rhs'].match(/10x3csupx3e(-?\d+)x3c\/supx3e/)
+        rate *= 10**power[1].to_i unless power.nil?
+        rate
       end
 
       ##


### PR DESCRIPTION
This is a follow-up to https://github.com/RubyMoney/google_currency/pull/3 from andersonbrandon.

If you try to change VND against USD, google will return something like "1 (Vietnamese dong / U.S. dollar) = 4.8 × 10-5"

In fetch_rate, the data['rhs'] values is "4.8 x26#215; 10x3csupx3e-5x3c/supx3e U.S. dollars", and the resulting gsub will be "4.8262151033533", which is wrong for 2 reasons: it grabs numbers that shouldn't be, and it ignores the power of 10.

Not sure what I did is the best way to do it, but it works.

Thanks for this great gem!
