### PR TITLE
Fixed "invalid multibyte escape" error under Ruby 1.9.2 when run from within TextMate

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -111,7 +111,7 @@ class Money
         data.gsub!(/rhs:/, '"rhs":')
         data.gsub!(/error:/, '"error":')
         data.gsub!(/icc:/, '"icc":')
-        data.gsub!(/(\\x..|\240)/, '')
+        data.gsub!(Regexp.new("(\\x..|\240)"), '')
 
         MultiJson.decode(data)
       end


### PR DESCRIPTION
Similar to eg. this one:

https://github.com/sstephenson/sprockets/issues/79

//Lars
