### PR TITLE
Update Money requirement to ~5.1.0

### DIFF
--- a/google_currency.gemspec
+++ b/google_currency.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "yajl-ruby", ">= 1.0.0"
   s.add_development_dependency "ffi"
 
-  s.add_dependency "money", "~> 5.0.0"
+  s.add_dependency "money", "~> 5.1.0"
   s.add_dependency "multi_json", ">= 1.0.0"
 
   s.files =  Dir.glob("{lib,spec}/**/*")


### PR DESCRIPTION
So we can install it with latest money-rails gem.

https://github.com/RubyMoney/google_currency/issues/14
