### PR TITLE
Fixes #16: Fixup encoding of strings returned from the Google API.

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -107,6 +107,8 @@ class Money
       #
       # @return [Hash]
       def fix_response_json_data(data)
+        data = data.force_encoding("ISO-8859-1").encode("UTF-8")
+
         data.gsub!(/lhs:/, '"lhs":')
         data.gsub!(/rhs:/, '"rhs":')
         data.gsub!(/error:/, '"error":')

--- a/spec/google_currency_with_json_spec.rb
+++ b/spec/google_currency_with_json_spec.rb
@@ -32,12 +32,23 @@ describe "GoogleCurrency" do
       @bank.rates.should include('USD_TO_EUR')
     end
 
-    it "should handle complex rates" do
-      uri = double('uri')
-      @bank.stub(:build_uri){|from,to| uri }
-      uri.stub(:read) { %q({lhs: "1 Vietnamese dong",rhs: "4.8 \x26#215; 10\x3csup\x3e-5\x3c/sup\x3e U.S. dollars",error: "",icc: true}) }
+    context "handles" do
 
-      @bank.get_rate('VND', 'USD').should == BigDecimal("0.48215105E1")
+      before :each do
+        @uri = double('uri')
+        @bank.stub(:build_uri){ |from,to| @uri }
+      end
+
+      it "Vietnamese Dong" do
+        @uri.stub(:read) { %q({lhs: "1 Vietnamese dong",rhs: "4.8 \x26#215; 10\x3csup\x3e-5\x3c/sup\x3e U.S. dollars",error: "",icc: true}) }
+        @bank.get_rate('VND', 'USD').should == BigDecimal("0.48215105E1")
+      end
+
+      it "Indonesian Rupie" do
+        @uri.stub(:read) { "{lhs: \"1 U.S. dollar\",rhs: \"10\xA0000 Indonesian rupiahs\",error: \"\",icc: true}" }
+        @bank.get_rate('IDR', 'USD').should == BigDecimal("0.1E5")
+      end
+
     end
   end
 


### PR DESCRIPTION
The Google API returns ISO-8859-1 encoding, not UTF-8.
