### PR TITLE
Permit to automatically expire rates after a given amount of seconds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 andersonbrandon
+cover
 Donald Ball
 Daniel Doubrovkine
 James Chen

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec
 group :development do
   gem 'rake'
 end
+
+group :test do
+  gem 'timecop'
+end

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ Usage
     require 'json'
     MultiJson.engine = :json_gem # or :yajl
 
+    # (optional)
+    # set the seconds after than the current rates are automatically expired
+    # by default, they never expire
+    Money::Bank::GoogleCurrency.ttl_in_seconds = 86400
+
     # set default bank to instance of GoogleCurrency
     Money.default_bank = Money::Bank::GoogleCurrency.new
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,4 @@
+require 'timecop'
+
 RSpec.configure do |config|
 end


### PR DESCRIPTION
One think that I miss is the ability to automatically flush rates, especially when running on background jobs or webservers that aren't restarted frequently, with the risk of using days old rates. I've added this to permit to automatically expire all the rates after a given amount of seconds. I hope you find it useful too :)
