### PR TITLE
Better rate fetch failure handling

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -104,7 +104,7 @@ class Money
             retries += 1
             if retries < 3
               retry
-            elsif pre_expired_rate
+            elsif preexpired_rate
               # We got an error fetching the rate. Re-cache expired rate.
               return @rates[rate_key_for(from, to)] ||= preexpired_rate
             else


### PR DESCRIPTION
If the rate fetch fails, retry 3 times. If it still fails after 3 retries, and we previously had a cached value for that rate, keep using the cached value. If all 3 retries fail and we have no previously cached rate, raise the HTTP error.
