### PR TITLE
Rails 4.2 support

### DIFF
--- a/google_currency.gemspec
+++ b/google_currency.gemspec
@@ -9,13 +9,11 @@ Gem::Specification.new do |s|
   s.description = "GoogleCurrency extends Money::Bank::Base and gives you access to the current Google Currency exchange rates."
   s.license     = 'MIT'
 
-  s.required_rubygems_version = ">= 1.3.6"
-
-  s.add_development_dependency "rspec", ">= 2.0.0"
+  s.add_development_dependency "rspec", ">= 3.0.0"
   s.add_development_dependency "yard", ">= 0.5.8"
   s.add_development_dependency "ffi"
 
-  s.add_dependency "money", "~> 6.0"
+  s.add_dependency "money", "~> 6.5.0"
 
   s.files =  Dir.glob("{lib,spec}/**/*")
   s.files += %w(LICENSE README.md CHANGELOG.md AUTHORS)

--- a/spec/google_currency_with_json_spec.rb
+++ b/spec/google_currency_with_json_spec.rb
@@ -10,7 +10,7 @@ describe "GoogleCurrency" do
 
   it "should accept a ttl_in_seconds option" do
     Money::Bank::GoogleCurrency.ttl_in_seconds = 86400
-    Money::Bank::GoogleCurrency.ttl_in_seconds.should eql(86400)
+    expect(Money::Bank::GoogleCurrency.ttl_in_seconds).to eq(86400)
   end
 
   describe ".refresh_rates_expiration!" do
@@ -19,56 +19,56 @@ describe "GoogleCurrency" do
       new_time = Time.now
       Timecop.freeze(new_time)
       Money::Bank::GoogleCurrency.refresh_rates_expiration!
-      Money::Bank::GoogleCurrency.rates_expiration.should eql(new_time + 86400)
+      expect(Money::Bank::GoogleCurrency.rates_expiration).to eq(new_time + 86400)
     end
   end
 
   describe "#get_rate" do
     it "should try to expire the rates" do
-      @bank.should_receive(:expire_rates).once
+      expect(@bank).to receive(:expire_rates).once
       @bank.get_rate('USD', 'USD')
     end
 
     it "should use #fetch_rate when rate is unknown" do
-      @bank.should_receive(:fetch_rate).once
+      expect(@bank).to receive(:fetch_rate).once
       @bank.get_rate('USD', 'USD')
     end
 
     it "should not use #fetch_rate when rate is known" do
       @bank.get_rate('USD', 'USD')
-      @bank.should_not_receive(:fetch_rate)
+      expect(@bank).to_not receive(:fetch_rate)
       @bank.get_rate('USD', 'USD')
     end
 
     it "should return the correct rate" do
-      @bank.get_rate('USD', 'USD').should == 1.0
+      expect(@bank.get_rate('USD', 'USD')).to eq(1.0)
     end
 
     it "should store the rate for faster retreival" do
       @bank.get_rate('USD', 'EUR')
-      @bank.rates.should include('USD_TO_EUR')
+      expect(@bank.rates).to include('USD_TO_EUR')
     end
 
     context "handles" do
       before :each do
         @uri = double('uri')
-        @bank.stub(:build_uri){ |from,to| @uri }
+        allow(@bank).to receive(:build_uri){ |from,to| @uri }
       end
 
       it "should return rate when it is known" do
-        @uri.stub(:read) { load_rate_http_response("sgd_to_usd") }
-        @bank.get_rate('SGD', 'USD').should == BigDecimal("0.8066")
+        allow(@uri).to receive(:read) { load_rate_http_response("sgd_to_usd") }
+        expect(@bank.get_rate('SGD', 'USD')).to eq(BigDecimal("0.8066"))
       end
 
       it "should raise UnknownRate error when rate is not known" do
-        @uri.stub(:read) { load_rate_http_response("vnd_to_usd") }
+        allow(@uri).to receive(:read) { load_rate_http_response("vnd_to_usd") }
         expect {
           @bank.get_rate('VND', 'USD')
         }.to raise_error(Money::Bank::UnknownRate)
       end
 
       it "should raise GoogleCurrencyFetchError there is an unknown issue with extracting the exchange rate" do
-        @uri.stub(:read) { load_rate_http_response("error") }
+        allow(@uri).to receive(:read) { load_rate_http_response("error") }
         expect {
           @bank.get_rate('VND', 'USD')
         }.to raise_error(Money::Bank::GoogleCurrencyFetchError)
@@ -80,7 +80,7 @@ describe "GoogleCurrency" do
     it "should empty @rates" do
       @bank.get_rate('USD', 'EUR')
       @bank.flush_rates
-      @bank.rates.should == {}
+      expect(@bank.rates).to eq({})
     end
   end
 
@@ -89,8 +89,8 @@ describe "GoogleCurrency" do
       @bank.get_rate('USD', 'EUR')
       @bank.get_rate('USD', 'JPY')
       @bank.flush_rate('USD', 'EUR')
-      @bank.rates.should include('USD_TO_JPY')
-      @bank.rates.should_not include('USD_TO_EUR')
+      expect(@bank.rates).to include('USD_TO_JPY')
+      expect(@bank.rates).to_not include('USD_TO_EUR')
     end
   end
 
@@ -106,7 +106,7 @@ describe "GoogleCurrency" do
       end
 
       it "should flush all rates" do
-        @bank.should_receive(:flush_rates)
+        expect(@bank).to receive(:flush_rates)
         @bank.expire_rates
       end
 
@@ -114,13 +114,13 @@ describe "GoogleCurrency" do
         exp_time = Time.now + 1000
 
         @bank.expire_rates
-        Money::Bank::GoogleCurrency.rates_expiration.should eql(exp_time)
+        expect(Money::Bank::GoogleCurrency.rates_expiration).to eq(exp_time)
       end
     end
 
     context "when the ttl has not expired" do
       it "not should flush all rates" do
-        @bank.should_not_receive(:flush_rates)
+        expect(@bank).to_not receive(:flush_rates)
         @bank.expire_rates
       end
     end


### PR DESCRIPTION
This allows for `google_currency` to be used in Rails 4.2. I've just copied how [eu_central_bank](https://github.com/RubyMoney/eu_central_bank) has been updated, and fixed outdated rspec syntax.