### PR TITLE
Use inverse for certain currency codes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ Lars Pind
 Shane Emmons
 sowenjub
 yinquanteo
+Tarang Patel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+3.2.1
+=====
+- Increase precision of rates by using inverse reciprocals for certain currencyes
+
 3.0.0
 =====
 

--- a/google_currency.gemspec
+++ b/google_currency.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = "google_currency"
-  s.version     = "3.2.0"
+  s.version     = "3.2.1"
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Shane Emmons"]
   s.email       = ["semmons99@gmail.com"]

--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -13,7 +13,6 @@ class Money
 
       SERVICE_HOST = "www.google.com"
       SERVICE_PATH = "/finance/converter"
-      INVERSE_PAIRS = ["IDR", "JPY", "KES", "INR"]
 
 
       # @return [Hash] Stores the currently known rates.
@@ -129,13 +128,14 @@ class Money
 
         from, to = Currency.wrap(from), Currency.wrap(to)
 
-        if INVERSE_PAIRS.include? from    
-            data = build_uri(to, from).read
-            1/extract_rate(data)
-        else
-            data = build_uri(from, to).read
-            extract_rate(data)
+        data = build_uri(from, to).read
+        rate = extract_rate(data);
+
+        if (rate < 0.1)
+          rate = 1/extract_rate(build_uri(to, from).read)
         end
+
+        rate
 
       end
 

--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -13,6 +13,8 @@ class Money
 
       SERVICE_HOST = "www.google.com"
       SERVICE_PATH = "/finance/converter"
+      INVERSE_PAIRS = ["IDR", "JPY", "KES", "INR"]
+
 
       # @return [Hash] Stores the currently known rates.
       attr_reader :rates
@@ -124,9 +126,17 @@ class Money
       #
       # @return [BigDecimal] The requested rate.
       def fetch_rate(from, to)
+
         from, to = Currency.wrap(from), Currency.wrap(to)
-        data = build_uri(from, to).read
-        extract_rate(data)
+
+        if INVERSE_PAIRS.include? from    
+            data = build_uri(to, from).read
+            1/extract_rate(data)
+        else
+            data = build_uri(from, to).read
+            extract_rate(data)
+        end
+
       end
 
       ##


### PR DESCRIPTION
This pull uses the inverse & reciprocal for JPY, IDR and INR currency conversions. This should be more precise.

Caveats of this technique should be conversions between the currencies mentioned in the array. In general there should be an increase in precision regardless.

This may be a better way to go than to have a disclaimer.