### PR TITLE
Update README with unsupported currencies and exchanges

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,176 @@ Consequently, this means that small exchange rates will be imprecise.
 For example, if the IDR to USD exchange rate were 0.00007761, Google will report it as 0.0001.
 This means 100000 IDR would exchange to 10 USD instead of 7.76 USD.
 
+Known issues
+------------
+
+Unsupported currencies: `BYN`, `CUC`, `EEK`, `GGP`, `GHC`, `IMP`, `JEP`, `MTL`,
+`SSP`, `TMM`, `XAG`, `XAU`, `YEN`, `ZWD`, `ZWN`, `ZWR`.
+
+Unsupported exchanges:
+- `AED -> ZMK`
+- `AFN -> SKK, ZMK, BTC`
+- `ALL -> SKK, ZMK, BTC`
+- `AMD -> SKK, ZMK, BTC`
+- `ANG -> ZMK`
+- `AOA -> SKK, ZMK, BTC`
+- `ARS -> ZMK`
+- `AUD -> ZMK`
+- `AWG -> SKK, ZMK`
+- `AZN -> SKK, ZMK`
+- `BAM -> SKK, ZMK`
+- `BBD -> SKK, ZMK`
+- `BDT -> ZMK, BTC`
+- `BGN -> ZMK`
+- `BHD -> ZMK`
+- `BIF -> CLF, SKK, ZMK, BTC`
+- `BMD -> SKK, ZMK`
+- `BND -> ZMK`
+- `BOB -> ZMK`
+- `BRL -> ZMK`
+- `BSD -> SKK, ZMK`
+- `BTC -> SKK, ZMK`
+- `BTN -> SKK, ZMK, BTC`
+- `BWP -> ZMK`
+- `BYR -> BHD, CLF, EUR, FKP, GBP, GIP, JOD, KWD, KYD, LVL, OMR, SHP, SKK, XDR, ZMK, BTC`
+- `BZD -> SKK, ZMK`
+- `CAD -> ZMK`
+- `CDF -> CLF, SKK, ZMK, BTC`
+- `CHF -> ZMK`
+- `CLF -> SKK, ZMK`
+- `CLP -> CLF, ZMK, BTC`
+- `CNY -> ZMK`
+- `COP -> CLF, ZMK, BTC`
+- `CRC -> CLF, ZMK, BTC`
+- `CUP -> SKK, ZMK`
+- `CVE -> SKK, ZMK, BTC`
+- `CZK -> ZMK`
+- `DJF -> SKK, ZMK, BTC`
+- `DKK -> ZMK`
+- `DOP -> ZMK, BTC`
+- `DZD -> ZMK, BTC`
+- `EGP -> ZMK`
+- `ERN -> SKK, ZMK`
+- `ETB -> SKK, ZMK`
+- `EUR -> ZMK`
+- `FJD -> ZMK`
+- `FKP -> SKK, ZMK`
+- `GBP -> ZMK`
+- `GEL -> SKK, ZMK`
+- `GHS -> SKK, ZMK`
+- `GIP -> SKK, ZMK`
+- `GMD -> SKK, ZMK`
+- `GNF -> CLF, KWD, SKK, ZMK, BTC`
+- `GTQ -> SKK, ZMK`
+- `GYD -> SKK, ZMK, BTC`
+- `HKD -> ZMK`
+- `HNL -> ZMK`
+- `HRK -> ZMK`
+- `HTG -> SKK, ZMK, BTC`
+- `HUF -> ZMK, BTC`
+- `IDR -> BHD, CLF, FKP, KWD, LVL, OMR, ZMK, BTC`
+- `ILS -> ZMK`
+- `INR -> ZMK, BTC`
+- `IQD -> CLF, SKK, ZMK, BTC`
+- `IRR -> AUD, AZN, BHD, BMD, BND, BSD, CAD, CHF, CLF, CUP, EUR, FKP, GBP, GIP, JOD, KWD, KYD, LVL, LYD, NZD, OMR, PAB, SGD, SHP, SKK, USD, XDR, ZMK, BTC`
+- `ISK -> SKK, ZMK, BTC`
+- `JMD -> ZMK, BTC`
+- `JOD -> ZMK`
+- `JPY -> ZMK, BTC`
+- `KES -> ZMK, BTC`
+- `KGS -> SKK, ZMK, BTC`
+- `KHR -> CLF, SKK, ZMK, BTC`
+- `KMF -> SKK, ZMK, BTC`
+- `KPW -> CLF, SKK, ZMK, BTC`
+- `KRW -> CLF, ZMK, BTC`
+- `KWD -> ZMK`
+- `KYD -> ZMK`
+- `KZT -> ZMK, BTC`
+- `LAK -> BHD, CLF, KWD, OMR, SKK, ZMK, BTC`
+- `LBP -> CLF, ZMK, BTC`
+- `LKR -> ZMK, BTC`
+- `LRD -> SKK, ZMK, BTC`
+- `LSL -> SKK, ZMK`
+- `LTL -> ZMK`
+- `LVL -> ZMK`
+- `LYD -> SKK, ZMK`
+- `MAD -> ZMK`
+- `MDL -> ZMK`
+- `MGA -> CLF, SKK, ZMK, BTC`
+- `MKD -> ZMK, BTC`
+- `MMK -> CLF, SKK, ZMK, BTC`
+- `MNT -> CLF, SKK, ZMK, BTC`
+- `MOP -> SKK, ZMK`
+- `MRO -> SKK, ZMK, BTC`
+- `MUR -> ZMK`
+- `MVR -> ZMK`
+- `MWK -> CLF, SKK, ZMK, BTC`
+- `MXN -> ZMK`
+- `MYR -> ZMK`
+- `MZN -> SKK, ZMK, BTC`
+- `NAD -> ZMK`
+- `NGN -> ZMK, BTC`
+- `NIO -> ZMK`
+- `NOK -> ZMK`
+- `NPR -> ZMK, BTC`
+- `NZD -> ZMK`
+- `OMR -> ZMK`
+- `PAB -> SKK, ZMK`
+- `PEN -> ZMK`
+- `PGK -> ZMK`
+- `PHP -> ZMK, BTC`
+- `PKR -> ZMK, BTC`
+- `PLN -> ZMK`
+- `PYG -> CLF, ZMK, BTC`
+- `QAR -> ZMK`
+- `RON -> ZMK`
+- `RSD -> ZMK, BTC`
+- `RUB -> ZMK, BTC`
+- `RWF -> CLF, SKK, ZMK, BTC`
+- `SAR -> ZMK`
+- `SBD -> SKK, ZMK`
+- `SCR -> ZMK`
+- `SDG -> SKK, ZMK`
+- `SEK -> ZMK`
+- `SGD -> ZMK`
+- `SHP -> SKK, ZMK`
+- `SKK -> AFN, ALL, AMD, AOA, AWG, AZN, BAM, BBD, BIF, BMD, BSD, BTN, BYR, BZD, CDF, CLF, CUP, CVE, DJF, ERN, ETB, FKP, GEL, GHS, GIP, GMD, GNF, GTQ, GYD, HTG, IQD, IRR, ISK, KGS, KHR, KMF, KPW, LAK, LRD, LSL, LYD, MGA, MMK, MNT, MOP, MRO, MWK, MZN, PAB, RWF, SBD, SDG, SHP, SOS, SRD, STD, SYP, SZL, TJS, TMT, TOP, VUV, WST, XCD, XDR, XPF, BTC, ZWL`
+- `SLL -> CLF, ZMK, BTC`
+- `SOS -> CLF, SKK, ZMK, BTC`
+- `SRD -> SKK, ZMK`
+- `STD -> BHD, BMD, BSD, CHF, CLF, CUP, EUR, FKP, GBP, GIP, JOD, KWD, KYD, LVL, OMR, PAB, SHP, SKK, USD, XDR, ZMK, BTC`
+- `SVC -> ZMK`
+- `SYP -> SKK, ZMK, BTC`
+- `SZL -> SKK, ZMK`
+- `THB -> ZMK`
+- `TJS -> SKK, ZMK`
+- `TMT -> SKK, ZMK`
+- `TND -> ZMK`
+- `TOP -> SKK, ZMK`
+- `TRY -> ZMK`
+- `TTD -> ZMK`
+- `TWD -> ZMK`
+- `TZS -> CLF, ZMK, BTC`
+- `UAH -> ZMK`
+- `UGX -> CLF, ZMK, BTC`
+- `USD -> ZMK`
+- `UYU -> ZMK`
+- `UZS -> CLF, ZMK, BTC`
+- `VEF -> ZMK`
+- `VND -> BHD, BMD, BSD, CHF, CLF, CUP, EUR, FKP, GBP, GIP, JOD, KWD, KYD, LVL, OMR, PAB, SHP, USD, XDR, ZMK, BTC`
+- `VUV -> SKK, ZMK, BTC`
+- `WST -> SKK, ZMK`
+- `XAF -> CLF, ZMK, BTC`
+- `XCD -> SKK, ZMK`
+- `XDR -> SKK, ZMK`
+- `XOF -> CLF, ZMK, BTC`
+- `XPF -> SKK, ZMK, BTC`
+- `YER -> ZMK, BTC`
+- `ZAR -> ZMK`
+- `ZMK -> AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN, BAM, BBD, BDT, BGN, BHD, BMD, BND, BOB, BRL, BSD, BTN, BWP, BZD, CAD, CHF, CLF, CLP, CNY, CRC, CUP, CVE, CZK, DJF, DKK, DOP, DZD, EGP, ERN, ETB, EUR, FJD, FKP, GBP, GEL, GHS, GIP, GMD, GTQ, GYD, HKD, HNL, HRK, HTG, HUF, ILS, INR, ISK, JMD, JOD, JPY, KES, KGS, KMF, KWD, KYD, KZT, LKR, LRD, LSL, LTL, LVL, LYD, MAD, MDL, MKD, MOP, MRO, MUR, MVR, MWK, MXN, MYR, MZN, NAD, NGN, NIO, NOK, NPR, NZD, OMR, PAB, PEN, PGK, PHP, PKR, PLN, QAR, RON, RSD, RUB, SAR, SBD, SCR, SDG, SEK, SGD, SHP, SRD, SVC, SYP, SZL, THB, TJS, TMT, TND, TOP, TRY, TTD, TWD, UAH, USD, UYU, VEF, VUV, WST, XAF, XCD, XDR, XOF, XPF, YER, ZAR, ZMW, BTC, ZWL`
+- `ZMW -> ZMK`
+- `ZWL -> SKK, ZMK, BTC`
+
 Copyright
 ---------
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Google Currency
 This gem extends Money::Bank::VariableExchange with Money::Bank::GoogleCurrency
 and gives you access to the current Google Currency exchange rates.
 
+**WARNING! [Google Finance Converter](https://www.google.com/finance/converter)
+(used by this gem) has been deprecated by Google. It is still available, but no
+longer supported. Use at your own risk!**
+
 Usage
 -----
 


### PR DESCRIPTION
I did a bit of testing around Google Finance Converter and found out that not only it doesn't support all the currencies that `money` gem has, but it also has a list of exchanges that it can not perform.

Here's a script that I used:

``` ruby
require 'money'
require 'money/bank/google_currency'

Money.default_bank = Money::Bank::GoogleCurrency.new

rate_error = {}

Money::Currency.stringified_keys.each do |from|
  Money::Currency.stringified_keys.each do |to|
    begin
      Money.new(100_00, from).exchange_to(to)
    rescue Money::Bank::UnknownRate
      rate_error[from] ||= []
      rate_error[from] << to
    rescue StandardError
      p "Unsupported currency: #{from} or #{to}"
    end
  end
end
```

Also, since every exchange rate is fetched one by one, the whole process took quite a bit of time and ate 144MB (!!!) of traffic. Which makes me think that we need to deprecate this gem in favour of something better.
