### PR TITLE
Retry common intermittent network exceptions

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -123,20 +123,17 @@ class Money
       #
       # @return [BigDecimal] The requested rate.
       def fetch_rate(from, to)
-
         from, to = Currency.wrap(from), Currency.wrap(to)
 
-        rate = retryable(tries: 3, on: [Errno::ECONNREFUSED, OpenURI::HTTPError, Errno::ENETUNREACH]) do
-          data = build_uri(from, to).read
-          extract_rate(data)
-        end
-
-        if (rate < 0.1)
-          rate = 1/extract_rate(build_uri(to, from).read)
-        end
-
+        rate = extract_rate(read_rate(from, to))
+        rate = 1/extract_rate(read_rate(to, from)) if (rate < 0.1)
         rate
+      end
 
+      def read_rate(c1, c2)
+        retryable(tries: 3, on: [Errno::ECONNREFUSED, OpenURI::HTTPError, Errno::ENETUNREACH]) do
+          build_uri(c1, c2).read
+        end
       end
 
       ##

--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -128,9 +128,8 @@ class Money
 
         rate = retryable(tries: 3, on: Errno::ECONNREFUSED) do
           data = build_uri(from, to).read
+          extract_rate(data)
         end
-
-        extract_rate(data)
 
         if (rate < 0.1)
           rate = 1/extract_rate(build_uri(to, from).read)

--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -164,7 +164,7 @@ class Money
       end
 
       def read_rate(c1, c2)
-        retryable(tries: 3, on: [Errno::ECONNREFUSED, OpenURI::HTTPError, Errno::ENETUNREACH]) do
+        retryable(tries: 3, on: [Errno::ECONNREFUSED, OpenURI::HTTPError, Errno::ENETUNREACH, Net::OpenTimeout]) do
           build_uri(c1, c2).read
         end
       end


### PR DESCRIPTION
https://www.google.com/finance/converter, has been quite flaky of late, commonly returning intermittent exceptions: `[Errno::ECONNREFUSED, OpenURI::HTTPError, Errno::ENETUNREACH]`

This has been causing some pain for us.

This PR implements a simply retry. We've had this code running in production for over a month and seems to solve the problem completely. So far at least. It would be great to get this merged in if you like the direction.