### PR TITLE
Replaced www.google.com by finance.google.com

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -16,7 +16,7 @@ class Money
     class GoogleCurrency < Money::Bank::VariableExchange
 
 
-      SERVICE_HOST = "www.google.com"
+      SERVICE_HOST = "finance.google.com"
       SERVICE_PATH = "/finance/converter"
 
 


### PR DESCRIPTION
Hi, it seems Google has changed something and that www.google.com/finance/converter is now redirecting to finance.google.com/finance/converter without giving the currency conversion. So the current version does not work any more. The fix is simple, I just had to replace www.google.com by finance.google.com