### PR TITLE
Fix for deprecated url

### DIFF
--- a/lib/money/bank/google_currency.rb
+++ b/lib/money/bank/google_currency.rb
@@ -17,7 +17,7 @@ class Money
 
 
       SERVICE_HOST = "finance.google.com"
-      SERVICE_PATH = "/finance/converter"
+      SERVICE_PATH = "/bctzjpnsun/converter"
 
 
       # @return [Hash] Stores the currently known rates.


### PR DESCRIPTION
Google Finance API Currency Converter not working is the latest problem suffered by all developers right now.

Explanations here:
https://www.techbuy.in/google-finance-api-currency-converter-not-working-updated-link-check-currency-converter/